### PR TITLE
docs: 在 README 中新增 macOS 安装指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This mod elegantly increases the multiplayer lobby limit. By default, it perfect
 
 macOS requires placing the mod inside the `.app` bundle and running the game under Rosetta 2.
 
+> **Note:** Online multiplayer has not been tested on macOS. The mod is only confirmed to launch correctly and show as loaded in the bottom-right corner.
+
 1. Download the latest `sts2-RMP-[version].zip` from the **Releases** page.
 2. Extract the archive and copy the inner `RemoveMultiplayerPlayerLimit` folder to:
    ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,6 +48,8 @@
 
 macOS 需要将模组放入 `.app` 包内部，并通过 Rosetta 2 运行游戏。
 
+> **注意：** 尚未进行联机实测，仅能保证正确打开游戏并且右下角显示正常载入模组。
+
 1. 从 **Releases** 页面下载最新的 `sts2-RMP-[version].zip` 压缩包。
 2. 解压并将内部的 `RemoveMultiplayerPlayerLimit` 文件夹复制到：
    ```


### PR DESCRIPTION
- 在 README.md 和 README_ZH.md 的安装说明中新增 macOS (Apple Silicon) 分区
- 提供两种 Rosetta 2 启动方式（访达 / 终端）
- 补充 `steam_appid.txt` 创建步骤，解决绕过 Steam 启动时的 "Steam failed to initialize" 错误（e.g. 如下：
<img width="957" height="565" alt="image" src="https://github.com/user-attachments/assets/e9a1a6bf-9067-49cc-bc13-2c2f5da50494" />
- 更新 Platform 徽章为 Windows | macOS