### PR TITLE
修复
  8 人及以上联机时部分玩家断连的问题

### DIFF
--- a/src/Network/SerializationPatches.cs
+++ b/src/Network/SerializationPatches.cs
@@ -1,9 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Multiplayer;
-using MegaCrit.Sts2.Core.Multiplayer.Messages.Lobby;
+using MegaCrit.Sts2.Core.Logging;
 using MegaCrit.Sts2.Core.Multiplayer.Serialization;
 
 namespace RemoveMultiplayerPlayerLimit.Network;
@@ -13,10 +14,9 @@ namespace RemoveMultiplayerPlayerLimit.Network;
 // ║                                                                        ║
 // ║  修改官方协议消息的 SlotId / LobbyList 序列化位宽：                       ║
 // ║    • LobbyPlayer.slotId           : 2 → 4 bits                         ║
-// ║    • ClientLobbyJoinResponse.list : 3 → 5 bits                         ║
-// ║    • LobbyBeginRunMessage.list    : 3 → 5 bits                         ║
+// ║    • Lobby message player lists   : 3 → 5 bits                         ║
 // ║                                                                        ║
-// ║  每个消息的 Serialize / Deserialize 各一个补丁，成对保证位宽一致。         ║
+// ║  Lobby 列表补丁扫描官方 Lobby 消息，避免漏掉 8 人时才触发的消息。          ║
 // ╚══════════════════════════════════════════════════════════════════════════╝
 
 /// <summary>
@@ -68,46 +68,89 @@ internal static class LobbyPlayerDeserializePatch
 			nameof(LobbyPlayerDeserializePatch));
 }
 
-// ── ClientLobbyJoinResponseMessage ─────────────────────────────────────
+// ── Lobby message player lists ─────────────────────────────────────────
 
-[HarmonyPatch(typeof(ClientLobbyJoinResponseMessage), nameof(ClientLobbyJoinResponseMessage.Serialize))]
-internal static class ClientLobbyJoinResponseSerializePatch
+[HarmonyPatch]
+internal static class LobbyMessageSerializeListPatch
 {
-	private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-		=> TranspilerUtils.ReplaceBitWidthBeforeCall(instructions,
+	private static IEnumerable<MethodBase> TargetMethods()
+		=> LobbyMessagePatchTargets.GetPacketMethods(nameof(IPacketSerializable.Serialize), typeof(PacketWriter));
+
+	private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, MethodBase __originalMethod)
+		=> LobbyMessagePatchTargets.ReplaceLobbyListBits(instructions,
 			SerializationMethods.WriteListWithBits,
-			ProtocolConfig.VanillaLobbyListLengthBits, ProtocolConfig.LobbyListLengthBits,
-			nameof(ClientLobbyJoinResponseSerializePatch));
+			nameof(LobbyMessageSerializeListPatch),
+			__originalMethod);
 }
 
-[HarmonyPatch(typeof(ClientLobbyJoinResponseMessage), nameof(ClientLobbyJoinResponseMessage.Deserialize))]
-internal static class ClientLobbyJoinResponseDeserializePatch
+[HarmonyPatch]
+internal static class LobbyMessageDeserializeListPatch
 {
-	private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-		=> TranspilerUtils.ReplaceBitWidthBeforeCall(instructions,
+	private static IEnumerable<MethodBase> TargetMethods()
+		=> LobbyMessagePatchTargets.GetPacketMethods(nameof(IPacketSerializable.Deserialize), typeof(PacketReader));
+
+	private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, MethodBase __originalMethod)
+		=> LobbyMessagePatchTargets.ReplaceLobbyListBits(instructions,
 			SerializationMethods.ReadListWithBits,
-			ProtocolConfig.VanillaLobbyListLengthBits, ProtocolConfig.LobbyListLengthBits,
-			nameof(ClientLobbyJoinResponseDeserializePatch));
+			nameof(LobbyMessageDeserializeListPatch),
+			__originalMethod);
 }
 
-// ── LobbyBeginRunMessage ───────────────────────────────────────────────
-
-[HarmonyPatch(typeof(LobbyBeginRunMessage), nameof(LobbyBeginRunMessage.Serialize))]
-internal static class LobbyBeginRunSerializePatch
+internal static class LobbyMessagePatchTargets
 {
-	private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-		=> TranspilerUtils.ReplaceBitWidthBeforeCall(instructions,
-			SerializationMethods.WriteListWithBits,
-			ProtocolConfig.VanillaLobbyListLengthBits, ProtocolConfig.LobbyListLengthBits,
-			nameof(LobbyBeginRunSerializePatch));
-}
+	private const string LobbyMessagesNamespace = "MegaCrit.Sts2.Core.Multiplayer.Messages.Lobby";
 
-[HarmonyPatch(typeof(LobbyBeginRunMessage), nameof(LobbyBeginRunMessage.Deserialize))]
-internal static class LobbyBeginRunDeserializePatch
-{
-	private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-		=> TranspilerUtils.ReplaceBitWidthBeforeCall(instructions,
-			SerializationMethods.ReadListWithBits,
-			ProtocolConfig.VanillaLobbyListLengthBits, ProtocolConfig.LobbyListLengthBits,
-			nameof(LobbyBeginRunDeserializePatch));
+	internal static IEnumerable<MethodBase> GetPacketMethods(string methodName, Type packetType)
+	{
+		foreach (Type type in GetSts2Types())
+		{
+			if (type.Namespace != LobbyMessagesNamespace || type.IsAbstract)
+			{
+				continue;
+			}
+			MethodInfo? method = type.GetMethod(methodName,
+				BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+				null,
+				new[] { packetType },
+				null);
+			if (method == null || method.IsAbstract || method.DeclaringType != type)
+			{
+				continue;
+			}
+			yield return method;
+		}
+	}
+
+	internal static IEnumerable<CodeInstruction> ReplaceLobbyListBits(
+		IEnumerable<CodeInstruction> instructions,
+		MethodInfo? targetMethod,
+		string patchName,
+		MethodBase originalMethod)
+	{
+		IEnumerable<CodeInstruction> result = TranspilerUtils.ReplaceBitWidthBeforeCall(instructions,
+			targetMethod,
+			ProtocolConfig.VanillaLobbyListLengthBits,
+			ProtocolConfig.LobbyListLengthBits,
+			patchName,
+			requireReplacement: false,
+			out int replacementCount);
+
+		if (replacementCount > 0)
+		{
+			Log.Info($"{patchName}: widened {replacementCount} lobby list bit-width operand(s) in {originalMethod.DeclaringType?.Name}.{originalMethod.Name}.");
+		}
+		return result;
+	}
+
+	private static IEnumerable<Type> GetSts2Types()
+	{
+		try
+		{
+			return typeof(LobbyPlayer).Assembly.GetTypes();
+		}
+		catch (ReflectionTypeLoadException ex)
+		{
+			return ex.Types.Where(type => type != null).Cast<Type>();
+		}
+	}
 }

--- a/src/Network/TranspilerUtils.cs
+++ b/src/Network/TranspilerUtils.cs
@@ -37,6 +37,22 @@ internal static class TranspilerUtils
 		int sourceBitWidth,
 		int targetBitWidth,
 		string patchName)
+		=> ReplaceBitWidthBeforeCall(instructions,
+			targetMethod,
+			sourceBitWidth,
+			targetBitWidth,
+			patchName,
+			requireReplacement: true,
+			out _);
+
+	internal static IEnumerable<CodeInstruction> ReplaceBitWidthBeforeCall(
+		IEnumerable<CodeInstruction> instructions,
+		MethodInfo? targetMethod,
+		int sourceBitWidth,
+		int targetBitWidth,
+		string patchName,
+		bool requireReplacement,
+		out int replacementCount)
 	{
 		MethodInfo resolvedTargetMethod = targetMethod
 			?? throw new InvalidOperationException($"{patchName}: target method is null.");
@@ -59,7 +75,9 @@ internal static class TranspilerUtils
 			count++;
 		}
 
-		if (count == 0)
+		replacementCount = count;
+
+		if (requireReplacement && count == 0)
 		{
 			throw new InvalidOperationException(
 				$"{patchName}: no bit-width operand replaced for method " +


### PR DESCRIPTION
﻿## 修改内容

本 PR 尝试修复 8 人及以上联机时部分玩家断连的问题。

主要修改：

- 保留 `LobbyPlayer.slotId` 从 2 bits 扩展到 4 bits，用于支持 0-15 共 16 个玩家槽位
- 将 Lobby 玩家列表长度从 3 bits 扩展到 5 bits
- 不再只 patch 两个已知 Lobby 消息，而是扫描所有官方 Lobby 消息中的 `Serialize` / `Deserialize`
- 只要发现官方 Lobby 消息中使用 3 bits 读写玩家列表长度，就替换为 5 bits
- 对没有玩家列表的 Lobby 消息允许跳过，避免误报补丁失败

## 原因说明

第 8 个玩家的 slotId 是 7，可以被 3 bits 表达。

但大厅玩家列表长度在 8 人时会变成 8。玩家列表长度是数量，不是从 0 开始的槽位下标，因此 8 已经超出了 3 bits 的表达范围。

如果某些官方 Lobby 消息仍然使用 3 bits 读写玩家列表长度，就可能导致网络包序列化/反序列化异常或数据错位，从而造成部分客户端断连。

## 说明

5 bits 可以表达 0-31，足够当前 16 人上限使用。

当前代码中的最大人数仍然会被限制在 16。

Fixes #21
